### PR TITLE
Add support for 'lume' template in project setup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,13 +26,14 @@ pub fn parse_new_args(args: &[String]) -> Result<(Option<&String>, Option<Vec<St
                         "full" => {
                             templates.push(String::from("ripress"));
                             templates.push(String::from("wynd"));
+                            templates.push(String::from("lume"));
                         }
-                        "ripress" | "wynd" => {
+                        "ripress" | "wynd" | "lume" => {
                             templates.push(template_value);
                         }
                         _ => {
                             errors.push(format!(
-                                "Invalid template value '{}'. Valid values: full, ripress, wynd",
+                                "Invalid template value '{}'. Valid values: full, ripress, wynd, lume",
                                 args[i + 1]
                             ));
                         }
@@ -119,7 +120,7 @@ pub async fn create_project(
 
     println!("📦 Creating project `{}`", project_name);
 
-    let component_options = &["ripress", "wynd"];
+    let component_options = &["ripress", "wynd", "lume"];
 
     let selected_components = match templates {
         Some(templates) => templates,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ async fn main() {
         eprintln!("  hexstack new my-app");
         eprintln!("  hexstack new my-app --template full");
         eprintln!("  hexstack new my-app --template ripress");
+        eprintln!("  hexstack new my-app --template wynd");
+        eprintln!("  hexstack new my-app --template lume");
         return;
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -60,6 +60,13 @@ impl ProjectSetup {
                     description: "An Event Driven WebSocket library".to_string(),
                 },
             ),
+            (
+                "lume".to_string(),
+                ComponentConfig {
+                    description: "A simple and intuitive Query Builder inspired by Drizzle"
+                        .to_string(),
+                },
+            ),
         ])
     }
 
@@ -81,10 +88,38 @@ impl ProjectSetup {
                 },
             ),
             (
+                "lume".to_string(),
+                ProjectTemplate {
+                    name: "Lume Basic".to_string(),
+                    github_url: "https://github.com/Guru901/lume-only".to_string(),
+                },
+            ),
+            (
                 "ripress_wynd".to_string(),
                 ProjectTemplate {
                     name: "Ripress + Wynd".to_string(),
                     github_url: "https://github.com/Guru901/ripress-wynd".to_string(),
+                },
+            ),
+            (
+                "ripress_lume".to_string(),
+                ProjectTemplate {
+                    name: "Ripress + Lume".to_string(),
+                    github_url: "https://github.com/Guru901/ripress-lume".to_string(),
+                },
+            ),
+            (
+                "wynd_lume".to_string(),
+                ProjectTemplate {
+                    name: "Wynd + Lume".to_string(),
+                    github_url: "https://github.com/Guru901/wynd-lume".to_string(),
+                },
+            ),
+            (
+                "ripress_wynd_lume".to_string(),
+                ProjectTemplate {
+                    name: "Ripress + Wynd + Lume".to_string(),
+                    github_url: "https://github.com/Guru901/ripress-wynd-lume".to_string(),
                 },
             ),
             // React frontend templates
@@ -109,6 +144,27 @@ impl ProjectSetup {
                     github_url: "https://github.com/Guru901/ripress-wynd-react".to_string(),
                 },
             ),
+            (
+                "ripress-lume-react".to_string(),
+                ProjectTemplate {
+                    name: "Ripress + Lume + React".to_string(),
+                    github_url: "https://github.com/Guru901/ripress-lume-react".to_string(),
+                },
+            ),
+            (
+                "wynd-lume-react".to_string(),
+                ProjectTemplate {
+                    name: "Wynd + Lume + React".to_string(),
+                    github_url: "https://github.com/Guru901/wynd-lume-react".to_string(),
+                },
+            ),
+            (
+                "ripress-wynd-lume-react".to_string(),
+                ProjectTemplate {
+                    name: "Ripress + Wynd + Lume + React".to_string(),
+                    github_url: "https://github.com/Guru901/ripress-wynd-lume-react".to_string(),
+                },
+            ),
             // Svelte frontend templates
             (
                 "ripress-svelte".to_string(),
@@ -129,6 +185,27 @@ impl ProjectSetup {
                 ProjectTemplate {
                     name: "Ripress + Wynd + Svelte".to_string(),
                     github_url: "https://github.com/Guru901/ripress-wynd-svelte".to_string(),
+                },
+            ),
+            (
+                "ripress-lume-svelte".to_string(),
+                ProjectTemplate {
+                    name: "Ripress + Lume + Svelte".to_string(),
+                    github_url: "https://github.com/Guru901/ripress-lume-svelte".to_string(),
+                },
+            ),
+            (
+                "wynd-lume-svelte".to_string(),
+                ProjectTemplate {
+                    name: "Wynd + Lume + Svelte".to_string(),
+                    github_url: "https://github.com/Guru901/wynd-lume-svelte".to_string(),
+                },
+            ),
+            (
+                "ripress-wynd-lume-svelte".to_string(),
+                ProjectTemplate {
+                    name: "Ripress + Wynd + Lume + Svelte".to_string(),
+                    github_url: "https://github.com/Guru901/ripress-wynd-lume-svelte".to_string(),
                 },
             ),
         ])
@@ -155,21 +232,33 @@ impl ProjectSetup {
         // Priority order for template selection (considering frontend)
         let template_priorities = if has_react_frontend {
             [
+                ("ripress-wynd-lume-react", vec!["ripress", "wynd", "lume"]),
                 ("ripress-wynd-react", vec!["ripress", "wynd"]),
+                ("ripress-lume-react", vec!["ripress", "lume"]),
+                ("wynd-lume-react", vec!["wynd", "lume"]),
                 ("ripress-react", vec!["ripress"]),
                 ("wynd-react", vec!["wynd"]),
+                ("lume-react", vec!["lume"]),
             ]
         } else if has_svelte_frontend {
             [
+                ("ripress-wynd-lume-svelte", vec!["ripress", "wynd", "lume"]),
                 ("ripress-wynd-svelte", vec!["ripress", "wynd"]),
+                ("ripress-lume-svelte", vec!["ripress", "lume"]),
+                ("wynd-lume-svelte", vec!["wynd", "lume"]),
                 ("ripress-svelte", vec!["ripress"]),
                 ("wynd-svelte", vec!["wynd"]),
+                ("lume-svelte", vec!["lume"]),
             ]
         } else {
             [
+                ("ripress_wynd_lume", vec!["ripress", "wynd", "lume"]),
                 ("ripress_wynd", vec!["ripress", "wynd"]),
+                ("ripress_lume", vec!["ripress", "lume"]),
+                ("wynd_lume", vec!["wynd", "lume"]),
                 ("ripress", vec!["ripress"]),
                 ("wynd", vec!["wynd"]),
+                ("lume", vec!["lume"]),
             ]
         };
 


### PR DESCRIPTION
- Updated template options in `parse_new_args` and `create_project` functions to include 'lume'.
- Enhanced error messages to reflect the addition of 'lume' as a valid template.
- Added 'lume' configuration and project templates in `setup.rs`, including various combinations with existing templates.
- Updated template priority order to accommodate 'lume' for both React and Svelte frontends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the new “lume” component/template.
  - “Full” template now includes lume alongside existing components.
  - Expanded template combinations (including React and Svelte variants) for ripress, wynd, and lume.
  - Improved template selection to better handle multi-component setups.

- Documentation
  - CLI help/usage updated to list the new lume and wynd template options.
  - Error messages now reflect the expanded set of valid templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->